### PR TITLE
UVS-uppdateringar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: Lingolympiaden
 email: lingo@lingolympiad.org
 baseurl: ""
-url: "http://www.lingolympiad.org"
+url: "https://www.lingolympiad.org"
 
 # Build settings
 markdown: kramdown

--- a/faq.md
+++ b/faq.md
@@ -6,26 +6,32 @@ permalink: /faq/
 
 Lingolympiaden är en tävling i lingvistik och logik för gymnasieelever från hela Sverige. Tävlingen hålls en gång varje år och består av två omgångar: en öppen kvaltävling, och en final för de som fick bäst resultat i kvalet. Den fungerar dessutom som uttagning till den internationella lingvistikolympiaden, IOL.
 
-## Hur går kvaltävlingen till?
-Kvaltävlingen är ett tre timmars skriftligt prov, som består av ett antal lingvistikproblem av varierande svårighetsgrad. Provet skrivs individuellt och helt utan externa hjälpmedel. Tävlingen hålls och organiseras av intresserade lärare på invididuella gymnasieskolor, men rättas centralt av Lingolympiadens arrangörsgrupp. För elever i skolor där tävlingen inte organiseras går det även att skriva tävlingen på Stockholms universitet. Det är alltid gratis att delta i Lingolympiaden!
-
-*När hålls kvaltävlingen?* Lingolympiadens kvaltävling kommer att hållas den 8 november 2023.
-
-*Hur anmäler jag mig/min skola?* Läs mer om anmälan [här]({% post_url 2023-08-24-kval-anmalan %})! Kontakta oss gärna på [lingo@lingolympiad.org](mailto:lingo@lingolympiad.org) om du har frågor kring anmälan.
-
-## Hur går finaltävlingen till?
-De som gjort bäst ifrån sig i kvaltävlingen bjuds in till en nationell finalhelg vid något av de samarbetande universiteten. Finalen består av tävlingsmoment, träning, inspirerande föreläsningar och umgänge, och givetvis står Lingolympiaden för resa, mat och boende. Resultaten i finalen bestämmer vilka som får representera Sverige i den internationella lingvistikolympiaden.
-
-## Hur vet jag om Lingolympiaden hålls på min skola?
-Fråga din mentor eller annan lärare om vem som håller i Lingolympiaden på din skola. Om det inte är någon som ansvarar för tävlingen på din skola, be någon av dina lärare ta kontakt med Lingolympiadens arrangörsgrupp på [lingo@lingolympiad.org](mailto:lingo@lingolympiad.org).
+# Om lingvistikproblem
 
 ## Vad är ett lingvistikproblem?
 Uppgifterna i Lingolympiaden går oftast ut på att ta reda på de underliggande strukturerna i något eller några av världens över 7000 språk. Trots detta krävs inga särskilda förkunskaper för att lösa ens de svåraste uppgifterna: all information som behövs för en fullständig lösning finns redan i uppgiften, och resten är upp till lösarens logiska problemlösningsförmåga. Uppgifterna baseras på verklig språkdata, och knyter ofta an till lingvistiska aspekter som är utmärkande eller rentav unika för uppgiftsspråket.
 
 Vill du prova att lösa ett lingvistikproblem? Kolla i vårt [övningsuppgiftsarkiv](/ovning/)! Där kan du hitta uppgifter i alla möjliga svårighetsgrader, inklusive fullständiga problemset från tidigare Lingolympiader.
 
-## Kan man tävla på engelska?
-På senare tid har vi fått frågor om att tävla på engelska istället för svenska. Det är tyvärr inte så enkelt, vi har skapat problemen för tävlingen på svenska och majoriteten av dom som tävlar har svenska som modersmål. Vi kan diskutera kompromisser, t.ex. om elever kan läsa frågorna på svenska men skriver lösningarna på engelska eller ha med sig en engelsk-svensk ordbok. Kontakta oss i god tid (mer än två veckor före tävlingen) på lingo@lingolympiad.org så försöker vi lösa situationen.
+## Vem skapar uppgifterna i Lingolympiaden?
+Lingolympiadens problemset skapas av volontärer i Föreningen Lingolympiadens problemgrupp - ofta tidigare deltagare i Lingolympiaden. Längst ned i varje Lingolympiadproblem står namn på problemets författare. Innan problemen används i tävlingen testas de ordentligt av problemgruppens medlemmar.
 
-## Is it possible to compete in English?
-As this is the Swedish linguistic olympiad, the problem set is created in Swedish. The majority of the contestants are native Swedish speakers and we do not create a thorough translation into English. It may be possible to find a compromise, for example a student could hand in the solutions in English but read the problems in Swedish with a dictionary. Contact us well before the contest (two weeks before at least) and we'll see what we can do.
+Vill du veta mer om hur man skapar lingvistikproblem, eller vara med och skapa Lingolympiadens problemset? [**Bli medlem i Föreningen Lingolympiaden**](https://ebas.ungvetenskapssport.se/blimedlem/lingolympiaden) om du inte redan är det, och hör av dig till arrangörsgruppen ([lingo@lingolympiad.org](mailto:lingo@lingolympiad.org))!
+
+# Om Lingolympiadens kvaltävling
+
+## Hur går kvaltävlingen till?
+Kvaltävlingen är ett tre timmars skriftligt prov, som består av ett antal lingvistikproblem av varierande svårighetsgrad. Provet skrivs individuellt och helt utan externa hjälpmedel. Tävlingen hålls och organiseras av intresserade lärare på invididuella gymnasieskolor, men rättas centralt av Lingolympiadens arrangörsgrupp. För elever i skolor där tävlingen inte organiseras går det även att skriva tävlingen på Stockholms universitet. Det är alltid gratis att delta i Lingolympiaden!
+
+*När hålls kvaltävlingen?* Lingolympiadens kvaltävling hålls i november varje år.
+
+*Hur anmäler jag mig/min skola?* När anmälan är öppen kan du hitta mer information på [förstasidan](/index/). Kontakta oss gärna på [lingo@lingolympiad.org](mailto:lingo@lingolympiad.org) om du har frågor kring anmälan.
+
+## Hur vet jag om Lingolympiaden hålls på min skola?
+Fråga din mentor eller annan lärare om vem som håller i Lingolympiaden på din skola. Om det inte är någon som ansvarar för tävlingen på din skola, be någon av dina lärare anmäla skolan eller ta kontakt med Lingolympiadens arrangörsgrupp på [lingo@lingolympiad.org](mailto:lingo@lingolympiad.org) för mer information.
+
+## Kan man tävla på andra språk?
+På senare tid har vi fått frågor om att tävla på andra språk än svenska. Det är tyvärr inte så enkelt, vi har skapat problemen för tävlingen på svenska och majoriteten av dom som tävlar har svenska som modersmål. Vi kan diskutera kompromisser, t.ex. om elever kan läsa frågorna på svenska men skriver lösningarna på ett annat språk eller ha med sig en tvåspråkig ordbok. Kontakta oss i god tid (mer än två veckor före tävlingen) på lingo@lingolympiad.org så försöker vi lösa situationen.
+
+## Can I compete in English?
+As this is the Swedish linguistic olympiad, the problem set is created in Swedish. The majority of the contestants are native Swedish speakers and we do not create thorough translations into English or other languages. It may be possible to find a compromise -- for example, a student could hand in the solutions in another language but read the problems in Swedish with a dictionary. Contact us well before the contest (two weeks before at least) and we'll see what we can do.

--- a/index.md
+++ b/index.md
@@ -3,11 +3,13 @@ layout: default
 title:  Lingolympiaden
 ---
 
-Lingolympiaden är en tävling i lingvistisk problemlösning för gymnasiet. Det är gratis att delta och kräver inga särskilda förkunskaper. Kolla gärna på våra [tidigare uppgifter](ovning)!
+Lingolympiaden är en tävling i lingvistisk problemlösning för gymnasieelever från hela Sverige. Det är gratis att delta och kräver inga särskilda förkunskaper. 
 
-Tävligen består av två omgångar: en öppen kvaltävling följt av en finaltävling för de med bäst kvalresultat. Finalen hålls i Stockholm under en helg fylld med sociala aktiviteter, lingvistiska föreläsningar, och träning i lingvistisk problemlösning. Finalen fungerar även som svensk uttagning till den internationella lingvistikolympiaden [IOL](https://ioling.org).
+Tävligen består av två omgångar: 
+* En öppen kvaltävling, där deltagarna försöker lösa fem kluriga uppgifter på tre timmar. Kolla gärna på våra [tidigare uppgifter](ovning) för exempel!
+* En finaltävling för de som presterat bäst i kvaltävlingen. Finalen hålls på Stockholms universitet under en helg fylld med sociala aktiviteter, lingvistiska föreläsningar, och träning i lingvistisk problemlösning. Finalen fungerar även som svensk uttagning till den internationella lingvistikolympiaden [IOL](https://ioling.org).
 
-Anmälan till Lingolympiaden 2024 har öppnat! Läs mer om årets tävling och hur du anmäler dig/din skola [här]({% post_url 2023-08-24-kval-anmalan %}).
+Nästa kvaltävling kommer att hållas i november 2024. Är du intresserad av att delta? [**Bli medlem i Föreningen Lingolympiaden**](https://ebas.ungvetenskapssport.se/blimedlem/lingolympiaden) -- det är helt gratis, och du får ett mejl när vi öppnar anmälan till årets kval!
 
 <div class="hscroll">
 
@@ -33,16 +35,19 @@ Anmälan till Lingolympiaden 2024 har öppnat! Läs mer om årets tävling och h
   <tr>
     <th>När</th>
     <td>8 november 2023</td>
-    <td>Våren 2024</td>
-    <td>Juli 2024</td>
+    <td>23–24 mars 2024</td>
+    <td>23–31 juli 2024</td>
   </tr>
 </table>
 
 </div>
 
-Lingolympiaden arrangeras i samarbete med <a href="https://www.ling.su.se/">Institutionen för lingvistik på Stockholms universitet</a> och med stöd av Skolverket.
+Lingolympiaden arrangeras av [Föreningen Lingolympiaden](https://ebas.ungvetenskapssport.se/forening/lingolympiaden), som är medlemsförening i [förbundet Ung Vetenskapssport](https://ungvetenskapssport.se/). 
+Tävlingen arrangeras i samarbete med [Institutionen för lingvistik](https://www.su.se/institutionen-for-lingvistik/) på Stockholms universitet och med stöd av Skolverket.
 
 Följ oss på [Facebook](https://www.facebook.com/lingolympiaden/) och [Instagram](https://www.instagram.com/lingolympiaden/) för regelbundna uppdateringar om Lingolympiaden.
+
+Gå med i vår [Discord-server](https://discord.gg/2j4kKSXkU7) för att diskutera Lingolympiaden med arrangörerna och andra deltagare.
 
 <div class="divider"></div>
 


### PR DESCRIPTION
Uppdateringar på förstasidan och FAQ-sidan med info om Lingo-föreningen och UVS, samt rensning av inaktuell info om 2024-kvalet från FAQ-sidan.